### PR TITLE
Update drug breast cancer

### DIFF
--- a/Drug/BreastCancer.R
+++ b/Drug/BreastCancer.R
@@ -117,7 +117,7 @@ pdf(file = "BC_plot.pdf",width = 12,height = 3)
 DimPlot(SC.integrated, reduction = "umap", split.by = "sample",group.by = "celltype")
 dev.off()
 #Save data
-saveRDS(SC.data,file="TNBC_SCdata.rds")
+saveRDS(SC.integrated,file="TNBC_SCdata.rds")
 
 #Get differential genes from limma
 SC.integrated=readRDS("TNBC_SCdata.rds")

--- a/Drug/BreastCancer.R
+++ b/Drug/BreastCancer.R
@@ -294,15 +294,14 @@ Drug.ident.res<-readRDS("TNBC_drugs_limma_all.rds")
 GSE92742.gctx.path="GSE92742_Broad_LINCS_Level5_COMPZ.MODZ_n473647x12328.gctx"
 GSE70138.gctx.path="GSE70138_Broad_LINCS_Level5_COMPZ_n118050x12328.gctx"
 Tissue="breast"
-Drug.score<-DrugScore(SC.integrated=SC.integrated,
-                     Gene.data=Gene.list,
-                     Cell.type=NULL,
-                     Drug.data=Drug.ident.res,
-                     FDA.drug.only=F,
-                     Case=Case,
-                     Tissue="breast",
-                     GSE92742.gctx=GSE92742.gctx.path,
-                     GSE70138.gctx=GSE70138.gctx.path)
+
+cell_metadata <- SC.integrated@meta.data
+cell_metadata$cluster <- SC.integrated@meta.data$celltype
+
+Drug.score<-DrugScore(cell_metadata, cluster_degs = Gene.list, 
+                        cluster_drugs = Drug.ident.res, tissue = "breast", 
+                        case = Case, gse92742_gctx_path = GSE92742.gctx.path, 
+                        gse70138_gctx_path = GSE70138.gctx.path)
 saveRDS(Drug.score,file="TNBC_drugscore_all.rds")
 
 #Drug combination


### PR DESCRIPTION
1. Updated line 120 from SC.data to SC.integrated
2. The drug score function as mentioned in Single-cell-drug-repositioning/Drug/BreastCancer.R and Single-cell-drug-repositioning/Figure/BreastCancer_Figure.R throws the following error: 

>  Drug.score<-DrugScore(SC.integrated=SC.integrated, 
+                     Gene.data=Gene.list, 
+                     Cell.type=NULL, 
+                     Drug.data=Drug.ident.res, 
+                     FDA.drug.only=T, 
+                     Case=Case, 
+                     Tissue=Tissue, 
+                     GSE92742.gctx=GSE92742.gctx.path, 
+                     GSE70138.gctx=GSE70138.gctx.path) 
Error in DrugScore(SC.integrated = SC.integrated, Gene.data = Gene.list,  :  
  unused arguments (SC.integrated = SC.integrated, Gene.data = Gene.list, Cell.type = NULL, Drug.data = Drug.ident.res, FDA.drug.only = T, Case = Case, Tissue = Tissue, GSE92742.gctx = GSE92742.gctx.path, GSE70138.gctx = GSE70138.gctx.path) 

I was able to move ahead with the analysis using the following changes in the parameters: 

cell_metadata <- SC.integrated@meta.data 
cell_metadata$cluster <- SC.integrated@meta.data$celltype 
 
Drug.score <- DrugScore(cell_metadata, cluster_degs = Gene.list,  
                        cluster_drugs = Drug.ident.res, tissue = "breast",  
                        case = Case, gse92742_gctx_path = gse92742_gctx_path,  
                        gse70138_gctx_path = gse70138_gctx_path)